### PR TITLE
Add support for linking via Cocoapods

### DIFF
--- a/RNEventEmitter.podspec
+++ b/RNEventEmitter.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNEventEmitter"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['repository']['url']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Moving forward, ReactNative [will start using CocoaPods](https://github.com/react-native-community/releases/issues/116) as the default linking mechanism. This adds a .podspec so linking will work correctly.

Dependency for https://github.com/lufinkey/react-native-spotify/pull/121

### How to use

Put inside your project's `Podfile`:
```ruby
  pod 'RNEventEmitter', :path => '../node_modules/react-native-events'
```