### PR TITLE
update react native to 0.63.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "lufinkey",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.53.3"
+    "react-native": "~0.63.0"
   },
   "dependencies": {
     "events": "^3.0.0"


### PR DESCRIPTION
I'd like to use this library with the latest version of react native, but I continue to have peer dependency errors. Can we bump to react-native 0.63.x?

Thanks!